### PR TITLE
Fixed issue of not removing 'motionTracker' when chatHead is removed

### DIFF
--- a/vlog/src/main/java/com/android/girish/vlog/ChatHeads.kt
+++ b/vlog/src/main/java/com/android/girish/vlog/ChatHeads.kt
@@ -402,6 +402,7 @@ internal class ChatHeads(context: Context, val mContentViewModel: ContentViewMod
         removeAll()
         closeCaptured = false
         movingOutOfClose = false
+        VlogService.sInstance.windowManager.removeView(motionTracker)
     }
 
     fun removeAll() {


### PR DESCRIPTION
Yesterday I found your project on a subreddit r/androiddev & was really impressed!

I was looking through your code & was learning how you implemented Bubbles so I set some background coloring to the `view`s you are adding to `Window` & found some strange behavior. Take a look over this [sample video](https://drive.google.com/file/d/1g9iJSqEq8991QGABC4TNVMP4dcSvQO0o/view?usp=sharing). 

Turns out you are not removing the instance of `motionTracker` upon chatHead is remove. This keeps the overlay even when the bubble is removed & makes the underlying screen untouchable.

- This **PR** solves this issue.

TBH, I'm still trying to understand how the `Spring` system & all is built from ground-up & plugged to `WindowManager` overall it's amazing to look at how you built this. Hope this contribution is worth your time :)